### PR TITLE
Revert "build(deps): bump vuetify from 3.5.8 to 3.5.9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vue": "^3.4.21",
     "vue-i18n": "9.10.2",
     "vue-router": "^4.3.0",
-    "vuetify": "^3.5.9"
+    "vuetify": "^3.5.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,7 +2183,7 @@ __metadata:
     vue-router: "npm:^4.3.0"
     vue-tsc: "npm:^2.0.6"
     vue3-toastify: "npm:^0.2.1"
-    vuetify: "npm:^3.5.9"
+    vuetify: "npm:^3.5.8"
     xml2js: "npm:^0.6.2"
   languageName: unknown
   linkType: soft
@@ -7012,9 +7012,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vuetify@npm:^3.5.9":
-  version: 3.5.9
-  resolution: "vuetify@npm:3.5.9"
+"vuetify@npm:^3.5.8":
+  version: 3.5.8
+  resolution: "vuetify@npm:3.5.8"
   peerDependencies:
     typescript: ">=4.7"
     vite-plugin-vuetify: ">=1.0.0-alpha.12"
@@ -7030,7 +7030,7 @@ __metadata:
       optional: true
     webpack-plugin-vuetify:
       optional: true
-  checksum: 10/d06ddeed98cd527183016569bc2720eaf1fe4eeb7d1b2894330aaf357549101d87f05705d37115fbeba7a3c928e47f7513639ec4380a36cd18bf5f01501f82c3
+  checksum: 10/693f6c0e0e2fa3297c7a180317ef721abbf450f19c2c074806a6fec889fb2461f8568a386fccf4a23d6ebd7787c7fc39221ee4749c9335c1ac69878e563faeef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts GIP-RECIA/Collabsoft#133

https://github.com/vuetifyjs/vuetify/issues/19425